### PR TITLE
New connection weights post addNode()

### DIFF
--- a/src/genome.js
+++ b/src/genome.js
@@ -191,8 +191,8 @@ class Genome {
 		});
 
 		//New connections
-		let newConnection1 = new Connection(pickedConnection.fromNode, newNode, Math.random() * this.inputs * Math.sqrt(2 / this.inputs));
-		let newConnection2 = new Connection(newNode, pickedConnection.toNode, Math.random() * this.inputs * Math.sqrt(2 / this.inputs));
+		let newConnection1 = new Connection(pickedConnection.fromNode, newNode, 1);
+		let newConnection2 = new Connection(newNode, pickedConnection.toNode, pickedConnection.weight);
 
 		this.layers++;
 		this.connections.push(newConnection1); //Add connection


### PR DESCRIPTION
Bottom of page 107: http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf
"In the add node mutation, an existing connection is split and the new node placed where the old connection used to be. The old connection is disabled and two new connections are added to the genome. The new connection
leading into the new node receives a weight of 1, and the new connection leading out
receives the same weight as the old connection. This method of adding nodes was chosen in order to minimize the initial effect of the mutation."